### PR TITLE
fix: `lang` option

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -2,7 +2,8 @@ import Vue from 'vue'
 import VeeValidate, { Validator } from 'vee-validate'
 <% if (options.lang) { %>
 import <%= options.lang %> from 'vee-validate/dist/locale/<%= options.lang %>'
-
-Validator.localize('<%= options.lang %>', <%= options.lang %>)
 <% } %>
 Vue.use(VeeValidate, <%= JSON.stringify(options.nuxtValidateOptions, null, 2) %>)
+<% if (options.lang) { %>
+Validator.localize('<%= options.lang %>', <%= options.lang %>)
+<% } %>


### PR DESCRIPTION
`lang` option is currently ignored. `Validator.localize()` must be called after `Vue.use(VeeValidate)`