### PR TITLE
integration with nuxt-i18n 

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ module.exports = function nuxtValidate (moduleOptions) {
   // Remove module options
   const nuxtValidateOptions = Object.assign({}, options)
   delete nuxtValidateOptions.lang
+  delete nuxtValidateOptions.nuxti18n
 
   // Register plugin
   this.addPlugin({
@@ -17,7 +18,8 @@ module.exports = function nuxtValidate (moduleOptions) {
     fileName: 'vee-validate.js',
     options: {
       nuxtValidateOptions,
-      lang: moduleOptions.lang
+      lang: moduleOptions.lang,
+      nuxti18n: moduleOptions.nuxti18n
     }
   })
 }

--- a/plugin.js
+++ b/plugin.js
@@ -13,7 +13,7 @@ export default ({ app }, inject) => {
 
   <% if (options.nuxti18n) { %>
   const nuxti18n = <%= JSON.stringify(options.nuxti18n) %>
-  if (nuxti18n.locale && app.i18n && !app.i18n.beforeLanguageSwitch) {
+  if (nuxti18n.locale && app.i18n) {
     const validatorLocale = nuxti18n.locale[app.i18n.locale] || app.i18n.locale
     if (app.validator.locale !== validatorLocale) {
       import(`vee-validate/dist/locale/${validatorLocale}`).then(dic => {
@@ -21,7 +21,9 @@ export default ({ app }, inject) => {
       })
     }
 
+    const beforeLanguageSwitch = app.i18n.beforeLanguageSwitch
     app.i18n.beforeLanguageSwitch = (oldLocale, newLocale) => {
+      beforeLanguageSwitch(oldLocale, newLocale)
       const newValidatorLocale = nuxti18n.locale[newLocale] || newLocale
       import(`vee-validate/dist/locale/${newValidatorLocale}`).then(dic => {
         app.validator.localize(newValidatorLocale, dic)

--- a/plugin.js
+++ b/plugin.js
@@ -13,7 +13,7 @@ export default ({ app }, inject) => {
 
   <% if (options.nuxti18n) { %>
   const nuxti18n = <%= JSON.stringify(options.nuxti18n) %>
-  if (nuxti18n.locale) {
+  if (nuxti18n.locale && app.i18n && !app.i18n.beforeLanguageSwitch) {
     const validatorLocale = nuxti18n.locale[app.i18n.locale] ? nuxti18n.locale[app.i18n.locale] : app.i18n.locale
     if (app.validator.locale !== validatorLocale) {
       import(`vee-validate/dist/locale/${validatorLocale}`).then(dic => {

--- a/plugin.js
+++ b/plugin.js
@@ -10,4 +10,23 @@ Validator.localize('<%= options.lang %>', <%= options.lang %>)
 
 export default ({ app }, inject) => {
   app.validator = Validator
+
+  <% if (options.nuxti18n) { %>
+  const nuxti18n = <%= JSON.stringify(options.nuxti18n) %>
+  if (nuxti18n.locale) {
+    const validatorLocale = nuxti18n.locale[app.i18n.locale] ? nuxti18n.locale[app.i18n.locale] : app.i18n.locale
+    if (app.validator.locale !== validatorLocale) {
+      import(`vee-validate/dist/locale/${validatorLocale}`).then(dic => {
+        app.validator.localize(validatorLocale, dic)
+      })
+    }
+
+    app.i18n.beforeLanguageSwitch = (oldLocale, newLocale) => {
+      const newValidatorLocale = nuxti18n.locale[newLocale] ? nuxti18n.locale[newLocale] : newLocale
+      import(`vee-validate/dist/locale/${newValidatorLocale}`).then(dic => {
+        app.validator.localize(newValidatorLocale, dic)
+      })
+    };
+  }
+  <% } %>
 }

--- a/plugin.js
+++ b/plugin.js
@@ -7,3 +7,7 @@ Vue.use(VeeValidate, <%= JSON.stringify(options.nuxtValidateOptions, null, 2) %>
 <% if (options.lang) { %>
 Validator.localize('<%= options.lang %>', <%= options.lang %>)
 <% } %>
+
+export default ({ app }, inject) => {
+  app.validator = Validator
+}

--- a/plugin.js
+++ b/plugin.js
@@ -1,20 +1,20 @@
 import Vue from 'vue'
-import VeeValidate, { Validator } from 'vee-validate'
+import VeeValidate from 'vee-validate'
 <% if (options.lang) { %>
 import <%= options.lang %> from 'vee-validate/dist/locale/<%= options.lang %>'
 <% } %>
 Vue.use(VeeValidate, <%= JSON.stringify(options.nuxtValidateOptions, null, 2) %>)
 <% if (options.lang) { %>
-Validator.localize('<%= options.lang %>', <%= options.lang %>)
+VeeValidate.Validator.localize('<%= options.lang %>', <%= options.lang %>)
 <% } %>
 
 export default ({ app }, inject) => {
-  app.validator = Validator
+  app.validator = VeeValidate.Validator
 
   <% if (options.nuxti18n) { %>
   const nuxti18n = <%= JSON.stringify(options.nuxti18n) %>
   if (nuxti18n.locale && app.i18n && !app.i18n.beforeLanguageSwitch) {
-    const validatorLocale = nuxti18n.locale[app.i18n.locale] ? nuxti18n.locale[app.i18n.locale] : app.i18n.locale
+    const validatorLocale = nuxti18n.locale[app.i18n.locale] || app.i18n.locale
     if (app.validator.locale !== validatorLocale) {
       import(`vee-validate/dist/locale/${validatorLocale}`).then(dic => {
         app.validator.localize(validatorLocale, dic)
@@ -22,7 +22,7 @@ export default ({ app }, inject) => {
     }
 
     app.i18n.beforeLanguageSwitch = (oldLocale, newLocale) => {
-      const newValidatorLocale = nuxti18n.locale[newLocale] ? nuxti18n.locale[newLocale] : newLocale
+      const newValidatorLocale = nuxti18n.locale[newLocale] || newLocale
       import(`vee-validate/dist/locale/${newValidatorLocale}`).then(dic => {
         app.validator.localize(newValidatorLocale, dic)
       })


### PR DESCRIPTION
```js
modules: [
  // ...,
  [
    "nuxt-validate",
    {
      nuxti18n: {
        locale: {
          // `nuxt-i18n locale code` : `vee-validate locale name`
          en: "en",
          "zh-Hans": "zh_CN"
        }
      }
    }
  ],
  [
    "nuxt-i18n",
    {
      locales: [
        {
          code: "ja",
          iso: "ja",
          file: "ja.js"
        },
        {
          code: "en",
          iso: "en",
          file: "en.js"
        },
        {
          code: "zh-Hans",
          iso: "zh-Hans",
          file: "zh-hans.js"
        },
        {
          code: "vi",
          iso: "vi",
          file: "vi.js",
        }
      ],
      // ...
    }
  ],
  // ...,
]
```